### PR TITLE
Add two more envs in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,9 @@ clever env set N8N_RUNNERS_ENABLED true
 # Timezone settings (update with your local timezone)
 clever env set GENERIC_TIMEZONE "Europe/Paris"
 
+# Release type: dev|stable
+clever env set N8N_RELEASE_TYPE dev
+
 # Security settings (IMPORTANT: use strong, unique values)
 clever env set N8N_ENCRYPTION_KEY '<YOUR_SUPER_SECRET_ENCRYPTION_KEY>'
 

--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,9 @@ clever env set VUE_APP_URL_BASE_APP https://<YOUR_DOMAIN_NAME>/
 
 clever env set N8N_RUNNERS_ENABLED true
 
+# Timezone settings (update with your local timezone)
+clever env set GENERIC_TIMEZONE "Europe/Paris"
+
 # Security settings (IMPORTANT: use strong, unique values)
 clever env set N8N_ENCRYPTION_KEY '<YOUR_SUPER_SECRET_ENCRYPTION_KEY>'
 


### PR DESCRIPTION
- **doc: Add Timezone environment variable in README**
- **doc: Add Release type environment variable in README**

The Timezone is useful for RSS Feed triggers as example, since it uses a specific timezone to compare the datetime of the last item received to run. It needs to match the current timezone in order to work.

The Release type set to "dev" explains why we have a little `[dev]` next to the logo. Using the `stable` release type will ensure stability of the n8n instance.
